### PR TITLE
Todos los temas de iconos deben heredar al menos de adwaita, gnome y hicolor

### DIFF
--- a/huayra-accesible/index.theme
+++ b/huayra-accesible/index.theme
@@ -1,7 +1,6 @@
 [Icon Theme]
 Name=Huayra-Accesible
-
-Inherits=mate,crystalsvg
+Inherits=adwaita,gnome,hicolor
 Example=folder
 
 Directories=scalable/actions,scalable/apps,scalable/categories,scalable/devices,scalable/emblems,scalable/emotes,scalable/mimetypes,scalable/places,scalable/status,48x48/animations,scalable/actions-extra,scalable/apps-extra,scalable/categories-extra,scalable/devices-extra,scalable/emblems-extra,scalable/emotes-extra,scalable/mimetypes-extra,scalable/places-extra,scalable/status-extra

--- a/huayra-fresco-verde/index.theme
+++ b/huayra-fresco-verde/index.theme
@@ -1,7 +1,7 @@
 [Icon Theme]
 Name=Huayra Fresco Verde
 Comment=Tema de iconos Huayra Fresco Verde
-
+Inherits=adwaita,gnome,hicolor
 Directories=8x8/actions,8x8/apps,8x8/categories,8x8/devices,8x8/emblems,8x8/mimetypes,8x8/places,8x8/status,16x16/actions,16x16/apps,16x16/categories,16x16/devices,16x16/emblems,16x16/mimetypes,16x16/places,16x16/status,22x22/actions,22x22/apps,22x22/categories,22x22/devices,22x22/emblems,22x22/mimetypes,22x22/places,22x22/status,32x32/actions,32x32/apps,32x32/categories,32x32/devices,32x32/emblems,32x32/mimetypes,32x32/places,32x32/status,48x48/actions,48x48/apps,48x48/categories,48x48/devices,48x48/emblems,48x48/mimetypes,48x48/places,48x48/status,64x64/actions,64x64/apps,64x64/categories,64x64/devices,64x64/emblems,64x64/mimetypes,64x64/places,64x64/status,128x128/actions,128x128/apps,128x128/categories,128x128/devices,128x128/emblems,128x128/mimetypes,128x128/places,128x128/status,256x256/actions,256x256/apps,256x256/categories,256x256/devices,256x256/emblems,256x256/mimetypes,256x256/places,256x256/status,scalable/actions,scalable/apps,scalable/categories,scalable/devices,scalable/emblems,scalable/mimetypes,scalable/places,scalable/status
 
 [8x8/actions]

--- a/huayra-limbo/index.theme
+++ b/huayra-limbo/index.theme
@@ -1,6 +1,7 @@
 [Icon Theme]
 Name=Huayra Limbo
 Comment=Tema de iconos Huayra Limbo
+Inherits=adwaita,gnome,hicolor
 Directories=8x8/actions,8x8/apps,8x8/categories,8x8/devices,8x8/emblems,8x8/places,8x8/mimetypes,8x8/status,16x16/actions,16x16/apps,16x16/categories,16x16/devices,16x16/emblems,16x16/places,16x16/mimetypes,16x16/status,22x22/actions,22x22/apps,22x22/categories,22x22/devices,22x22/emblems,22x22/places,22x22/mimetypes,22x22/status,24x24/actions,24x24/apps,24x24/categories,24x24/devices,24x24/emblems,24x24/places,24x24/mimetypes,24x24/status,32x32/actions,32x32/apps,32x32/categories,32x32/devices,32x32/emblems,32x32/places,32x32/mimetypes,32x32/status,48x48/actions,48x48/apps,48x48/categories,48x48/devices,48x48/emblems,48x48/places,48x48/mimetypes,48x48/status,64x64/actions,64x64/apps,64x64/categories,64x64/devices,64x64/emblems,64x64/places,64x64/mimetypes,64x64/status,128x128/actions,128x128/apps,128x128/categories,128x128/devices,128x128/emblems,128x128/places,128x128/mimetypes,128x128/status,256x256/actions,256x256/apps,256x256/categories,256x256/devices,256x256/emblems,256x256/places,256x256/mimetypes,256x256/status,scalable/actions,scalable/apps,scalable/categories,scalable/devices,scalable/emblems,scalable/places,scalable/mimetypes,scalable/status
 
 [8x8/actions]

--- a/huayra-liso/index.theme
+++ b/huayra-liso/index.theme
@@ -1,6 +1,7 @@
 [Icon Theme]
 Name=Huayra Liso
 Comment=Tema de iconos en estilo plano
+Inherits=adwaita,gnome,hicolor
 Directories=8x8/actions,8x8/apps,8x8/categories,8x8/devices,8x8/emblems,8x8/places,8x8/mimetypes,8x8/status,16x16/actions,16x16/apps,16x16/categories,16x16/devices,16x16/emblems,16x16/places,16x16/mimetypes,16x16/status,22x22/actions,22x22/apps,22x22/categories,22x22/devices,22x22/emblems,22x22/places,22x22/mimetypes,22x22/status,24x24/actions,24x24/apps,24x24/categories,24x24/devices,24x24/emblems,24x24/places,24x24/mimetypes,24x24/status,32x32/actions,32x32/apps,32x32/categories,32x32/devices,32x32/emblems,32x32/places,32x32/mimetypes,32x32/status,48x48/actions,48x48/apps,48x48/categories,48x48/devices,48x48/emblems,48x48/places,48x48/mimetypes,48x48/status,64x64/actions,64x64/apps,64x64/categories,64x64/devices,64x64/emblems,64x64/places,64x64/mimetypes,64x64/status,128x128/actions,128x128/apps,128x128/categories,128x128/devices,128x128/emblems,128x128/places,128x128/mimetypes,128x128/status,256x256/actions,256x256/apps,256x256/categories,256x256/devices,256x256/emblems,256x256/places,256x256/mimetypes,256x256/status,scalable/actions,scalable/apps,scalable/categories,scalable/devices,scalable/emblems,scalable/places,scalable/mimetypes,scalable/status
 
 [8x8/actions]

--- a/huayra-mayo/index.theme
+++ b/huayra-mayo/index.theme
@@ -1,7 +1,7 @@
 [Icon Theme]
 Name=Huayra Mayo
 Comment=Tema de iconos Huayra Mayo
-
+Inherits=adwaita,gnome,hicolor
 Directories=8x8/actions,8x8/apps,8x8/categories,8x8/devices,8x8/emblems,8x8/mimetypes,8x8/places,8x8/status,16x16/actions,16x16/apps,16x16/categories,16x16/devices,16x16/emblems,16x16/mimetypes,16x16/places,16x16/status,22x22/actions,22x22/apps,22x22/categories,22x22/devices,22x22/emblems,22x22/mimetypes,22x22/places,22x22/status,32x32/actions,32x32/apps,32x32/categories,32x32/devices,32x32/emblems,32x32/mimetypes,32x32/places,32x32/status,48x48/actions,48x48/apps,48x48/categories,48x48/devices,48x48/emblems,48x48/mimetypes,48x48/places,48x48/status,64x64/actions,64x64/apps,64x64/categories,64x64/devices,64x64/emblems,64x64/mimetypes,64x64/places,64x64/status,128x128/actions,128x128/apps,128x128/categories,128x128/devices,128x128/emblems,128x128/mimetypes,128x128/places,128x128/status,256x256/actions,256x256/apps,256x256/categories,256x256/devices,256x256/emblems,256x256/mimetypes,256x256/places,256x256/status,scalable/actions,scalable/apps,scalable/categories,scalable/devices,scalable/emblems,scalable/mimetypes,scalable/places,scalable/status
 
 [8x8/actions]

--- a/huayra-violeta-v2/index.theme
+++ b/huayra-violeta-v2/index.theme
@@ -1,7 +1,7 @@
 [Icon Theme]
 Name=Huayra Violeta V2
 Comment=Tema de iconos Huayra Violeta (ver. 2)
-
+Inherits=adwaita,gnome,hicolor
 Directories=8x8/actions,8x8/apps,8x8/categories,8x8/devices,8x8/emblems,8x8/mimetypes,8x8/places,8x8/status,16x16/actions,16x16/apps,16x16/categories,16x16/devices,16x16/emblems,16x16/mimetypes,16x16/places,16x16/status,22x22/actions,22x22/apps,22x22/categories,22x22/devices,22x22/emblems,22x22/mimetypes,22x22/places,22x22/status,32x32/actions,32x32/apps,32x32/categories,32x32/devices,32x32/emblems,32x32/mimetypes,32x32/places,32x32/status,48x48/actions,48x48/apps,48x48/categories,48x48/devices,48x48/emblems,48x48/mimetypes,48x48/places,48x48/status,64x64/actions,64x64/apps,64x64/categories,64x64/devices,64x64/emblems,64x64/mimetypes,64x64/places,64x64/status,128x128/actions,128x128/apps,128x128/categories,128x128/devices,128x128/emblems,128x128/mimetypes,128x128/places,128x128/status,256x256/actions,256x256/apps,256x256/categories,256x256/devices,256x256/emblems,256x256/mimetypes,256x256/places,256x256/status,scalable/actions,scalable/apps,scalable/categories,scalable/devices,scalable/emblems,scalable/mimetypes,scalable/places,scalable/status
 
 [8x8/actions]

--- a/huayra-violeta/index.theme
+++ b/huayra-violeta/index.theme
@@ -1,7 +1,7 @@
 [Icon Theme]
 Name=Huayra Violeta
 Comment=Tema de iconos Huayra Violeta
-
+Inherits=adwaita,gnome,hicolor
 Directories=8x8/actions,8x8/apps,8x8/categories,8x8/devices,8x8/emblems,8x8/mimetypes,8x8/places,8x8/status,16x16/actions,16x16/apps,16x16/categories,16x16/devices,16x16/emblems,16x16/mimetypes,16x16/places,16x16/status,22x22/actions,22x22/apps,22x22/categories,22x22/devices,22x22/emblems,22x22/mimetypes,22x22/places,22x22/status,32x32/actions,32x32/apps,32x32/categories,32x32/devices,32x32/emblems,32x32/mimetypes,32x32/places,32x32/status,48x48/actions,48x48/apps,48x48/categories,48x48/devices,48x48/emblems,48x48/mimetypes,48x48/places,48x48/status,64x64/actions,64x64/apps,64x64/categories,64x64/devices,64x64/emblems,64x64/mimetypes,64x64/places,64x64/status,128x128/actions,128x128/apps,128x128/categories,128x128/devices,128x128/emblems,128x128/mimetypes,128x128/places,128x128/status,256x256/actions,256x256/apps,256x256/categories,256x256/devices,256x256/emblems,256x256/mimetypes,256x256/places,256x256/status,scalable/actions,scalable/apps,scalable/categories,scalable/devices,scalable/emblems,scalable/mimetypes,scalable/places,scalable/status
 
 [8x8/actions]


### PR DESCRIPTION
Esto arregla un crash en pluma, engrama y mate-panel por ejemplo.
La descripción completa del bug la envié por correo a la lista de desarrollo.

Lo mas importante es hicolor, porque todos las aplicaciones copian su icono por defecto ahi.
El resto son cuestionables, pero como son los temas mas completos esta bueno colocarlos.